### PR TITLE
[issue/#62] 카테고리 더보기 버튼 클릭 시 보이는 버튼은 하나만 보이도록 한다.

### DIFF
--- a/src/components/nav/SingleCategoryTree.vue
+++ b/src/components/nav/SingleCategoryTree.vue
@@ -18,7 +18,7 @@
     </div>
     <button class="btn--transparent moreButton" @click="showMoreButton(props.category)">
       <img :src="moreIcon" />
-      <more-button v-if="isMoreButtonShow"></more-button>
+      <more-button v-if="categoryTreeStore.moreBtnCategoryIdTree[props.category.id]"></more-button>
     </button>
   </li>
 </template>
@@ -64,8 +64,25 @@ const toCategoryPage = async (categoryId, categoryName) => {
   categoryStore.setCategoryName(categoryName)
 }
 
+const excludeItem = (obj, excludedKey) => {
+  let result = {}
+
+  for (let key in obj) {
+    if (key == excludedKey) {
+      result[key] = !obj[key]
+    } else {
+      result[key] = false
+    }
+  }
+  console.log(result)
+  return result
+}
+
 const showMoreButton = (categoryData) => {
-  isMoreButtonShow.value = !isMoreButtonShow.value
+  categoryTreeStore.moreBtnCategoryIdTree = excludeItem(
+    categoryTreeStore.moreBtnCategoryIdTree,
+    categoryData.id
+  )
   categoryStore.setFocusedCategory(categoryData.id)
   categoryStore.setFocusedCategoryData(categoryData)
 }

--- a/src/stores/useCategoryTreeStore.ts
+++ b/src/stores/useCategoryTreeStore.ts
@@ -10,6 +10,7 @@ export const useCategoryTreeStore = defineStore('categoryTree', () => {
   // 카테고리 트리 depth show/hide 컨트롤 용
   const categoryIdTree = ref<CategoryIdMap>({})
   const categoryIdTreeRadio = ref<CategoryIdMap>({})
+  const moreBtnCategoryIdTree = ref<CategoryIdMap>({})
 
   // 카테고리 트리 depth show/hide 컨트롤 용
   function showChildrenCategory(children: any) {
@@ -41,6 +42,7 @@ export const useCategoryTreeStore = defineStore('categoryTree', () => {
         const categoryIdMap = createCategoryIdMap(userCategoryList.value)
         categoryIdTree.value = categoryIdMap
         categoryIdTreeRadio.value = categoryIdMap
+        moreBtnCategoryIdTree.value = categoryIdMap
       }
     } catch (error) {
       console.log(error)
@@ -82,6 +84,7 @@ export const useCategoryTreeStore = defineStore('categoryTree', () => {
     getUserCategoryList,
     updateCategoryIdTree,
     showChildrenCategoryRadio,
-    updateUserCategoryList
+    updateUserCategoryList,
+    moreBtnCategoryIdTree
   }
 })


### PR DESCRIPTION
[내용]
- 더보기 버튼을 관리하는 moreBtnCategoryIdTree 상태값을 categoryTreeStore에 추가함
- 더보기 버튼 클릭 시 moreBtnCategoryIdTree에서 해당 카테고리의 boolean 값을 반전 시키고 나머지 카테고리들은 false 값을 주어 버튼이 닫히도록 처리함