### PR TITLE
refactor: 콘텐츠 상태관리 구조 개선

### DIFF
--- a/src/assets/model/defaultCategory.js
+++ b/src/assets/model/defaultCategory.js
@@ -1,0 +1,87 @@
+import categoryBook from '@/assets/img/category/img_category_book.png'
+import categoryCafe from '@/assets/img/category/img_category_cafe.png'
+import categoryCake from '@/assets/img/category/img_category_cake.png'
+import categoryCook from '@/assets/img/category/img_category_cook.png'
+import categoryDocument from '@/assets/img/category/img_category_document.png'
+import categoryFolder from '@/assets/img/category/img_category_folder.png'
+import categoryGame from '@/assets/img/category/img_category_game.png'
+import categoryGift from '@/assets/img/category/img_category_gift.png'
+import categoryShopping from '@/assets/img/category/img_category_shopping.png'
+import categoryStar from '@/assets/img/category/img_category_star.png'
+import categoryTrip from '@/assets/img/category/img_category_trip.png'
+import categoryWatch from '@/assets/img/category/img_category_watch.png'
+
+export const defaultCategoryList = [
+  {
+    id: 0,
+    img: categoryFolder,
+    selected: true,
+    iconName: 'Folder'
+  },
+  {
+    id: 1,
+    img: categoryCook,
+    selected: false,
+    iconName: 'Cook'
+  },
+  {
+    id: 2,
+    img: categoryCafe,
+    selected: false,
+    iconName: 'Cafe'
+  },
+  {
+    id: 3,
+    img: categoryCake,
+    selected: false,
+    iconName: 'Cake'
+  },
+  {
+    id: 4,
+    img: categoryWatch,
+    selected: false,
+    iconName: 'Watch'
+  },
+  {
+    id: 5,
+    img: categoryStar,
+    selected: false,
+    iconName: 'Star'
+  },
+  {
+    id: 6,
+    img: categoryGift,
+    selected: false,
+    iconName: 'Gift'
+  },
+  {
+    id: 7,
+    img: categoryShopping,
+    selected: false,
+    iconName: 'Shopping'
+  },
+  {
+    id: 8,
+    img: categoryDocument,
+    selected: false,
+    iconName: 'Document'
+  },
+  {
+    id: 9,
+    img: categoryBook,
+    selected: false,
+    iconName: 'Book'
+  },
+  {
+    id: 10,
+    img: categoryGame,
+    selected: false,
+    iconName: 'Game'
+  },
+  {
+    id: 11,
+    img: categoryTrip,
+    selected: false,
+    iconName: 'Trip'
+  }
+]

--- a/src/components/home/ContentsItem.vue
+++ b/src/components/home/ContentsItem.vue
@@ -137,8 +137,7 @@ const excludeItem = (obj, excludedKey) => {
 const showMoreButton = (contentData) => {
   console.log(contentData)
   contentStore.moreBtnContentIdTree = excludeItem(contentStore.moreBtnContentIdTree, contentData.id)
-  contentStore.setFocusedContent(contentData.id)
-  contentStore.setFocusedContentData(contentData)
+  contentStore.setFocusedContent(contentData)
 }
 
 const handleImageError = (event) => {

--- a/src/components/home/CustomCategoryPage.vue
+++ b/src/components/home/CustomCategoryPage.vue
@@ -2,12 +2,12 @@
   <title-bar></title-bar>
   <div class="divider"></div>
   <article class="contents-container">
-    <div class="contents-num__wrapper">{{ contentStore.userCustomContentList.length }}개</div>
+    <div class="contents-num__wrapper">{{ contentStore.contentList.length }}개</div>
     <!-- 콘텐츠 있을 때 -->
-    <template v-if="contentStore.userCustomContentList.length > 0">
+    <template v-if="contentStore.contentList.length > 0">
       <div class="contents-list__wrapper">
         <contents-item
-          v-for="item in contentStore.userCustomContentList"
+          v-for="item in contentStore.contentList"
           :item="item"
           :key="item"
         ></contents-item>
@@ -40,7 +40,7 @@ onMounted(async () => {
 })
 
 watch(
-  () => useContentStore.userCustomContentList,
+  () => useContentStore.contentList,
   () => {
     // 적절한 화면 갱신 로직 추가
     console.log('myState가 변경되었습니다. 화면을 갱신합니다.')

--- a/src/components/home/DefaultCategoryPage.vue
+++ b/src/components/home/DefaultCategoryPage.vue
@@ -2,19 +2,19 @@
   <title-bar></title-bar>
   <div class="divider"></div>
   <article class="contents-container">
-    <div class="contents-num__wrapper">{{ contentStore.userFilteredContentList.length }}개</div>
+    <div class="contents-num__wrapper">{{ contentStore.contentList.length }}개</div>
     <!-- 콘텐츠 있을 때 -->
-    <template v-if="contentStore.userFilteredContentList.length > 0">
+    <template v-if="contentStore.contentList.length > 0">
       <div class="contents-list__wrapper">
         <contents-item
-          v-for="item in contentStore.userFilteredContentList"
+          v-for="item in contentStore.contentList"
           :key="item"
           :item="item"
         ></contents-item>
       </div>
     </template>
     <!-- 콘텐츠 없을 떄 -->
-    <template v-if="contentStore.userFilteredContentList.length === 0">
+    <template v-if="contentStore.contentList.length === 0">
       <div class="flex-container__col contents__empty">
         <img :src="emptyImg" class="img-empty" />
         <span>저장된 콘텐츠가 없습니다.</span>
@@ -38,8 +38,8 @@ const contentList = ref({})
 
 onMounted(async () => {
   await contentStore.fetchAllContents()
-  if (contentStore.userContentList.length > 0) {
-    contentList.value = toRaw(contentStore.userContentList)
+  if (contentStore.allContentList.length > 0) {
+    contentList.value = toRaw(contentStore.allContentList)
     console.log(contentList, 'contentList')
   }
 
@@ -49,8 +49,8 @@ onMounted(async () => {
 
 // 콘텐츠 데이터 감시
 contentStore.$subscribe(() => {
-  if (contentStore.userContentList.length > 0) {
-    contentList.value = toRaw(contentStore.userContentList)
+  if (contentStore.allContentList.length > 0) {
+    contentList.value = toRaw(contentStore.allContentList)
   }
 })
 </script>

--- a/src/components/home/TheFilter.vue
+++ b/src/components/home/TheFilter.vue
@@ -36,13 +36,9 @@ const selectedOption = ref('recent')
 
 const sortContent = () => {
   if (selectedOption.value === 'recent') {
-    contentStore.userFilteredContentList = sortByCreatedAtDescending(
-      contentStore.userFilteredContentList
-    )
+    contentStore.contentList = sortByCreatedAtDescending(contentStore.contentList)
   } else {
-    contentStore.userFilteredContentList = sortByCreatedAtAscending(
-      contentStore.userFilteredContentList
-    )
+    contentStore.contentList = sortByCreatedAtAscending(contentStore.contentList)
   }
 }
 </script>

--- a/src/components/modal/ThumbnailItem.vue
+++ b/src/components/modal/ThumbnailItem.vue
@@ -1,30 +1,26 @@
 <template>
   <div class="box__thumbnail">
-    <img
-      class="thumbnail__sm"
-      :src="modalDataStore.addContentData.coverImg"
-      @error="handleImageError"
-    />
+    <img class="thumbnail__sm" :src="contentStore.contentObj.coverImg" @error="handleImageError" />
     <div class="wrapper__thumbnail-content">
       <div class="box__input--content-title">
-        <span class="text__contentTitle">{{ modalDataStore.addContentData.title }}</span>
+        <span class="text__contentTitle">{{ contentStore.contentObj.title }}</span>
         <button class="btn--transparent" @click="modalViewStore.showModal('editContentTitle')">
           <img :src="editIcon" />
         </button>
       </div>
-      <span class="text__contentLink">{{ modalDataStore.addContentData.link }}</span>
+      <span class="text__contentLink">{{ contentStore.contentObj.link }}</span>
     </div>
   </div>
 </template>
 
 <script setup>
 import editIcon from '@/assets/ic/ic-edit.svg'
-import { useModalDataStore } from '@/stores/useModalDataStore.ts'
 import { useModalViewStore } from '@/stores/useModalViewStore.ts'
 import defaultImg from '@/assets/img/img_default.png'
+import { useContentStore } from '@/stores/useContentStore.ts'
 
-const modalDataStore = useModalDataStore()
 const modalViewStore = useModalViewStore()
+const contentStore = useContentStore()
 
 const handleImageError = (event) => {
   event.target.src = defaultImg

--- a/src/components/modal/ThumbnailItemWithCheckbox.vue
+++ b/src/components/modal/ThumbnailItemWithCheckbox.vue
@@ -1,21 +1,25 @@
 <template>
   <div class="box__thumbnail--multiple">
     <div class="box__thumbnail-img" @click="modalDataStore.checkLinkInMultipleLink(index)">
-      <img class="thumbnail__sm" :src="contentData.coverImg" @error="handleImageError" />
+      <img
+        class="thumbnail__sm"
+        :src="contentStore.multipleContentList[index].coverImg"
+        @error="handleImageError"
+      />
       <!-- <img v-if="contentData.checked" class="thumbnail__checkbox" :src="checkboxOn" /> -->
       <button class="button__checkbox">
-        <img :src="checkboxOff" v-if="!contentData.checked" />
-        <img :src="checkboxOn" v-if="contentData.checked" />
+        <img :src="checkboxOff" v-if="!contentStore.multipleContentList[index].checked" />
+        <img :src="checkboxOn" v-if="contentStore.multipleContentList[index].checked" />
       </button>
     </div>
     <div class="wrapper__thumbnail-content">
       <div class="box__input--content-title">
-        <span class="text__contentTitle">{{ contentData.title }}</span>
+        <span class="text__contentTitle">{{ contentStore.multipleContentList[index].title }}</span>
         <button class="btn--transparent">
           <img :src="editIcon" @click="openEditContentTitleModal()" />
         </button>
       </div>
-      <span class="text__contentLink">{{ contentData.link }}</span>
+      <span class="text__contentLink">{{ contentStore.multipleContentList[index].link }}</span>
     </div>
   </div>
 </template>
@@ -27,22 +31,25 @@ import editIcon from '@/assets/ic/ic-edit.svg'
 import defaultImg from '@/assets/img/img_default.png'
 import { useModalDataStore } from '@/stores/useModalDataStore.ts'
 import { useModalViewStore } from '@/stores/useModalViewStore.ts'
+import { useContentStore } from '@/stores/useContentStore.ts'
 
 const modalDataStore = useModalDataStore()
 const modalViewStore = useModalViewStore()
 
 const props = defineProps({
-  contentData: Object,
   index: Number
 })
+
+const contentStore = useContentStore()
 
 const handleImageError = (event) => {
   event.target.src = defaultImg
 }
 
 const openEditContentTitleModal = () => {
-  modalDataStore.setFocusedAddContentIndex(props.index)
-  modalViewStore.hideModal('editContentTitle')
+  console.log('openEditContentTitle', props.index)
+  contentStore.setFocusedContentIndex(props.index)
+  modalViewStore.showModal('editContentTitle')
 }
 </script>
 

--- a/src/components/modal/content/ModalContentAddMultiple.vue
+++ b/src/components/modal/content/ModalContentAddMultiple.vue
@@ -6,12 +6,12 @@
       :closeModal="closeModal"
       :goBack="goBack"
     ></modal-header-step>
-    <div class="wrapper__content-num">{{ modalDataStore.addContentData.length }}개 콘텐츠</div>
+    <div class="wrapper__content-num">{{ contentStore.multipleContentList.length }}개 콘텐츠</div>
     <!-- 썸네일 -->
-    <template v-if="modalDataStore.addContentData.length > 0">
+    <template v-if="contentStore.multipleContentList.length > 0">
       <div class="wrapper__multiple-thumbnail">
         <thumbnail-item-with-checkbox
-          v-for="(data, index) in modalDataStore.addContentData"
+          v-for="(data, index) in contentStore.multipleContentList"
           :key="index"
           :contentData="data"
           :index="index"

--- a/src/components/modal/content/ModalContentAddSingle.vue
+++ b/src/components/modal/content/ModalContentAddSingle.vue
@@ -22,7 +22,7 @@
       <div class="flex-container__row--space-between">
         <label class="label__modal">즐겨찾기</label>
         <toggle-button
-          :value="modalDataStore.addContentData.favorite"
+          :value="contentStore.contentObj.favorite"
           :toggleOn="modalDataStore.setFavoriteToggle"
         ></toggle-button>
       </div>
@@ -54,7 +54,6 @@ import ThumbnailItem from '../ThumbnailItem.vue'
 import { useModalViewStore } from '@/stores/useModalViewStore.ts'
 import { useModalDataStore } from '@/stores/useModalDataStore.ts'
 import { useContentStore } from '@/stores/useContentStore.ts'
-import { onMounted } from 'vue'
 
 const modalViewStore = useModalViewStore()
 const modalDataStore = useModalDataStore()
@@ -62,24 +61,9 @@ const contentStore = useContentStore()
 
 const props = defineProps({
   modalTitle: String,
-  closeModal: Function
-})
-
-onMounted(() => {
-  if (props.modalTitle === '콘텐츠 수정') {
-    modalDataStore.addContentData.id = contentStore.focusedContentData.id
-    modalDataStore.addContentData.link = contentStore.focusedContentData.link
-    modalDataStore.addContentData.title = contentStore.focusedContentData.title
-    modalDataStore.addContentData.memo = contentStore.focusedContentData.memo
-    modalDataStore.addContentData.favorite = contentStore.focusedContentData.favorite
-    modalDataStore.selectedLocation.name = contentStore.focusedContentData.category
-      ? contentStore.focusedContentData.category.name
-      : '전체 콘텐츠'
-    modalDataStore.selectedLocation.parentId = contentStore.focusedContentData.parentId
-      ? contentStore.focusedContentData.parentId
-      : null
-    modalDataStore.addContentData.coverImg = contentStore.focusedContentData.coverImg
-  }
+  closeModal: Function,
+  goBack: Function,
+  content: Object
 })
 
 const setMemo = (e) => {
@@ -92,11 +76,6 @@ const saveContent = () => {
   } else {
     contentStore.editContent()
   }
-}
-
-const goBack = () => {
-  modalViewStore.hideModal('editContentDetail')
-  modalViewStore.openAddContentModal()
 }
 </script>
 

--- a/src/components/modal/content/ModalContentAddStep01.vue
+++ b/src/components/modal/content/ModalContentAddStep01.vue
@@ -39,7 +39,8 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { useModalViewStore } from '@/stores/useModalViewStore.ts'
-import { useModalDataStore } from '@/stores/useModalDataStore.ts'
+import { useContentStore } from '@/stores/useContentStore.ts'
+
 import spaceRectangle from '@/assets/img/spacebar-rectangle.png'
 
 import ModalHeader from '@/components/header/ModalHeader.vue'
@@ -51,7 +52,7 @@ const props = defineProps({
 })
 
 const modalViewStore = useModalViewStore()
-const modalDataStore = useModalDataStore()
+const contentStore = useContentStore()
 
 const link = ref('')
 
@@ -111,14 +112,14 @@ const submitLink = async () => {
 
   // 링크 1개인 경우
   if (numOfLink === 1) {
-    modalDataStore.setSingleLink(linkStr)
+    contentStore.setSingleLink(linkStr)
     modalViewStore.showModalWithOverlay('addContentDetail', 'default')
 
     // 링크 2개인 경우
   } else if (numOfLink > 1) {
     const linkArr = setMultipleLinkArr(linkStr)
-    const multipleLink = await modalDataStore.fetchMultipleLinksOgData(linkArr)
-    modalDataStore.setMultipleLinks(multipleLink)
+    const multipleLink = await contentStore.fetchMultipleLinksOgData(linkArr)
+    contentStore.setMultipleLinks(multipleLink)
     modalViewStore.showModalWithOverlay('addContentMultiple', 'default')
   }
 }

--- a/src/components/modal/content/ModalContentShare.vue
+++ b/src/components/modal/content/ModalContentShare.vue
@@ -5,7 +5,7 @@
       <input
         id="contentLink"
         class="input__sm--content-link"
-        :value="contentStore.focusedContentData.link"
+        :value="contentStore.contentObj.link"
         readonly
         @select="deselectText"
       />

--- a/src/components/modal/content/ModalEditContentTitle.vue
+++ b/src/components/modal/content/ModalEditContentTitle.vue
@@ -31,21 +31,18 @@
 
 <script setup>
 import topCloseIcon from '@/assets/ic/ic-top-close.svg'
-import { useModalDataStore } from '@/stores/useModalDataStore.ts'
 import { useModalViewStore } from '@/stores/useModalViewStore.ts'
+import { useContentStore } from '@/stores/useContentStore.ts'
 import { ref, computed } from 'vue'
 
-const modalDataStore = useModalDataStore()
 const modalViewStore = useModalViewStore()
-
-const isMultipleContent = computed(() => {
-  return modalDataStore.addContentData.length === undefined ? false : true
-})
+const contentStore = useContentStore()
+const isMultipleContent = ref(contentStore.multipleContentList.length >= 1 ? true : false)
 
 const title = ref(
   isMultipleContent.value
-    ? modalDataStore.addContentData[modalDataStore.focusedAddContentIndex].title
-    : modalDataStore.addContentData.title
+    ? contentStore.multipleContentList[contentStore.focusedContent.index].title
+    : contentStore.contentObj.title
 )
 
 const setTitle = (e) => {
@@ -58,9 +55,9 @@ const isTitleValid = computed(() => {
 
 const saveContentTitle = () => {
   if (isMultipleContent.value) {
-    modalDataStore.setMultipleTitle(title.value)
+    contentStore.setMultipleTitle(title.value)
   } else {
-    modalDataStore.setTitle(title.value)
+    contentStore.setContentTitle(title.value)
   }
   modalViewStore.hideModal('editContentTitle')
 }

--- a/src/components/nav/TheNavBar.vue
+++ b/src/components/nav/TheNavBar.vue
@@ -54,14 +54,12 @@ import { useCategoryTreeStore } from '@/stores/useCategoryTreeStore.ts'
 import { useRouter, useRoute } from 'vue-router'
 import mainLogo from '@/assets/logo/logo_black_20px.svg'
 import { onMounted } from 'vue'
-import { useModalDataStore } from '@/stores/useModalDataStore'
 import { useToastStore } from '@/stores/useToastStore.ts'
 
 const categoryTreeStore = useCategoryTreeStore()
 const userStore = useUserStore()
 const searchStore = useSearchStore()
 const modalViewStore = useModalViewStore()
-const modalDataStore = useModalDataStore()
 const toastStore = useToastStore()
 
 const router = useRouter()
@@ -82,7 +80,7 @@ const showAddModal = () => {
           message: '저장하기',
           execute: () => {
             modalViewStore.hideModalWithOverlay('select', 'default')
-            modalDataStore.setSingleLink(text)
+            contentStore.setSingleLink(text)
             modalViewStore.showModalWithOverlay('addContentDetail', 'default')
           }
         }

--- a/src/stores/useCategoryStore.ts
+++ b/src/stores/useCategoryStore.ts
@@ -154,30 +154,28 @@ export const useCategoryStore = defineStore('category', () => {
     if (isUnselectedChipOn.value === true) {
       // && 즐겨찾기 on
       if (isFavoriteChipOn.value === true) {
-        contentStore.userFilteredContentList = filterByFavoriteAndCategoryIsNull(
-          contentStore.userContentList
-        )
+        contentStore.contentList = filterByFavoriteAndCategoryIsNull(contentStore.allContentList)
       }
       // && 즐겨찾기 off
       else {
-        contentStore.userFilteredContentList = filterByCategoryIsNull(contentStore.userContentList)
+        contentStore.contentList = filterByCategoryIsNull(contentStore.allContentList)
       }
     }
     // 카테고리 미지정 off
     else {
       // && 즐겨찾기 on
       if (isFavoriteChipOn.value === true) {
-        contentStore.userFilteredContentList = filterByFavorite(contentStore.userContentList)
+        contentStore.contentList = filterByFavorite(contentStore.allContentList)
       }
       // && 즐겨찾기 off
       else {
-        contentStore.userFilteredContentList = contentStore.userContentList
+        contentStore.contentList = contentStore.allContentList
       }
     }
   }
 
   function resetContentChip() {
-    contentStore.userFilteredContentList = contentStore.userContentList
+    contentStore.contentList = contentStore.allContentList
     isFavoriteChipOn.value = false
     isUnselectedChipOn.value = false
   }
@@ -197,24 +195,22 @@ export const useCategoryStore = defineStore('category', () => {
     if (isUnselectedChipOn.value === true) {
       // && 즐겨찾기 on
       if (isFavoriteChipOn.value === true) {
-        contentStore.userFilteredContentList = filterByFavoriteAndCategoryIsNull(
-          contentStore.userContentList
-        )
+        contentStore.contentList = filterByFavoriteAndCategoryIsNull(contentStore.allContentList)
       }
       // && 즐겨찾기 off
       else {
-        contentStore.userFilteredContentList = filterByCategoryIsNull(contentStore.userContentList)
+        contentStore.contentList = filterByCategoryIsNull(contentStore.allContentList)
       }
     }
     // 카테고리 미지정 off
     else {
       // && 즐겨찾기 on
       if (isFavoriteChipOn.value === true) {
-        contentStore.userFilteredContentList = filterByFavorite(contentStore.userContentList)
+        contentStore.contentList = filterByFavorite(contentStore.allContentList)
       }
       // && 즐겨찾기 off
       else {
-        contentStore.userFilteredContentList = contentStore.userContentList
+        contentStore.contentList = contentStore.allContentList
       }
     }
   }

--- a/src/stores/useModalDataStore.ts
+++ b/src/stores/useModalDataStore.ts
@@ -1,94 +1,10 @@
 import { defineStore } from 'pinia'
-import categoryBook from '@/assets/img/category/img_category_book.png'
-import categoryCafe from '@/assets/img/category/img_category_cafe.png'
-import categoryCake from '@/assets/img/category/img_category_cake.png'
-import categoryCook from '@/assets/img/category/img_category_cook.png'
-import categoryDocument from '@/assets/img/category/img_category_document.png'
-import categoryFolder from '@/assets/img/category/img_category_folder.png'
-import categoryGame from '@/assets/img/category/img_category_game.png'
-import categoryGift from '@/assets/img/category/img_category_gift.png'
-import categoryShopping from '@/assets/img/category/img_category_shopping.png'
-import categoryStar from '@/assets/img/category/img_category_star.png'
-import categoryTrip from '@/assets/img/category/img_category_trip.png'
+import { defaultCategoryList } from '@/assets/model/defaultCategory'
 import categoryWatch from '@/assets/img/category/img_category_watch.png'
 import { ref, reactive, computed } from 'vue'
-import { getOgData } from '@/api/contents'
-
 export const useModalDataStore = defineStore('modalData', () => {
-  const defaultCategory = reactive([
-    {
-      id: 0,
-      img: categoryFolder,
-      selected: true,
-      iconName: 'Folder'
-    },
-    {
-      id: 1,
-      img: categoryCook,
-      selected: false,
-      iconName: 'Cook'
-    },
-    {
-      id: 2,
-      img: categoryCafe,
-      selected: false,
-      iconName: 'Cafe'
-    },
-    {
-      id: 3,
-      img: categoryCake,
-      selected: false,
-      iconName: 'Cake'
-    },
-    {
-      id: 4,
-      img: categoryWatch,
-      selected: false,
-      iconName: 'Watch'
-    },
-    {
-      id: 5,
-      img: categoryStar,
-      selected: false,
-      iconName: 'Star'
-    },
-    {
-      id: 6,
-      img: categoryGift,
-      selected: false,
-      iconName: 'Gift'
-    },
-    {
-      id: 7,
-      img: categoryShopping,
-      selected: false,
-      iconName: 'Shopping'
-    },
-    {
-      id: 8,
-      img: categoryDocument,
-      selected: false,
-      iconName: 'Document'
-    },
-    {
-      id: 9,
-      img: categoryBook,
-      selected: false,
-      iconName: 'Book'
-    },
-    {
-      id: 10,
-      img: categoryGame,
-      selected: false,
-      iconName: 'Game'
-    },
-    {
-      id: 11,
-      img: categoryTrip,
-      selected: false,
-      iconName: 'Trip'
-    }
-  ])
+  // 기본 카테고리 아이콘 정보
+  const defaultCategory = reactive(defaultCategoryList)
 
   // 카테고리 추가 모달
   const newCategoryName = ref('')
@@ -98,34 +14,15 @@ export const useModalDataStore = defineStore('modalData', () => {
     name: '전체 콘텐츠'
   })
 
-  // 콘텐츠 추가 모달 데이터 - 단일 링크
-  const addContentData: any = ref({
-    id: -1,
-    category: selectedLocation.value,
-    favorite: false,
-    memo: '',
-    link: '',
-    title: '',
-    coverImg: '',
-    siteName: '',
-    description: '',
-    parentId: ''
-  })
-
-  // 콘텐츠 추가 모달 데이터 - 단일 링크
-  const focusedAddContentIndex: any = ref()
-
-  const setFocusedAddContentIndex = (index: Number) => {
-    focusedAddContentIndex.value = index
-  }
-
   const getSelectedCategory: any = computed(() => {
     const selectedCategory = defaultCategory.find((e) => {
       return e.selected == true
     })
     return selectedCategory
   })
+
   const isSelectedCategory = () => selectedLocation.value.name !== '전체 콘텐츠'
+
   const getCategoryImgByIconName = (iconName: string) => {
     const icon: any = defaultCategory.find((e) => e.iconName === iconName)
     if (icon === undefined) {
@@ -160,99 +57,6 @@ export const useModalDataStore = defineStore('modalData', () => {
     selectedLocation.value = category
   }
 
-  // 콘텐츠 추가
-  function setAddContentData(contentData: any) {
-    addContentData.value.category = contentData.category
-      ? contentData.category
-      : addContentData.value.category
-    addContentData.value.memo = contentData.memo ? contentData.memo : addContentData.value.memo
-    addContentData.value.link = contentData.link ? contentData.link : addContentData.value.link
-    addContentData.value.title = contentData.title ? contentData.title : addContentData.value.title
-  }
-  function setFavoriteToggle() {
-    addContentData.value.favorite = !addContentData.value.favorite
-  }
-  function setMemo(contentAddMemo: string) {
-    addContentData.value.memo = contentAddMemo
-  }
-
-  function checkLinkInMultipleLink(index: any) {
-    console.log('isChecked', addContentData.value[index].checked)
-    addContentData.value[index].checked = !addContentData.value[index].checked
-  }
-
-  function setTitle(title: string) {
-    addContentData.value.title = title
-  }
-
-  function setMultipleTitle(title: string) {
-    addContentData.value[focusedAddContentIndex.value].title = title
-  }
-
-  // og 데이터 추출
-  async function fetchOgData(link: string) {
-    try {
-      const response: any = await getOgData(link)
-      console.log('ogdata', response)
-      if (response.data.statusCode === 200 || response.data.statusCode === 201) {
-        return response.data
-      }
-    } catch (error) {
-      console.log(error)
-    }
-  }
-
-  async function setSingleLink(link: string) {
-    addContentData.value.link = link
-    const ogData = await fetchOgData(link)
-    addContentData.value.coverImg = ogData.coverImg
-    addContentData.value.title = ogData.title
-    addContentData.value.description = ogData.description
-    addContentData.value.siteName = ogData.siteName
-  }
-
-  async function fetchMultipleLinksOgData(links: any) {
-    const multipleLinksArr: {
-      link: any
-      coverImg: any
-      title: any
-      description: any
-      siteName: any
-    }[] = []
-
-    for (let i = 0; i < links.length; i++) {
-      const ogData = await fetchOgData(links[i])
-      const linkData = {
-        link: links[i],
-        coverImg: ogData.coverImg,
-        title: ogData.title,
-        description: ogData.description,
-        siteName: ogData.siteName,
-        checked: true
-      }
-      multipleLinksArr.push(linkData)
-    }
-
-    return multipleLinksArr
-  }
-
-  function setMultipleLinks(linkArrData: any) {
-    addContentData.value = linkArrData
-  }
-
-  function resetAddContentData() {
-    addContentData.value.id = -1
-    addContentData.value.selectedLocation = { name: '전체 콘텐츠' }
-    addContentData.value.favorite = false
-    addContentData.value.memo = ''
-    addContentData.value.link = ''
-    addContentData.value.title = ''
-    addContentData.value.coverImg = ''
-    addContentData.value.siteName = ''
-    addContentData.value.description = ''
-    addContentData.value.parentId = ''
-  }
-
   return {
     defaultCategory,
     newCategoryName,
@@ -264,20 +68,6 @@ export const useModalDataStore = defineStore('modalData', () => {
     selectCategoryLocation,
     resetCategoryLocation,
     clickRadioButton,
-    addContentData,
-    setAddContentData,
-    setFavoriteToggle,
-    setMemo,
-    setSingleLink,
-    setMultipleLinks,
-    setTitle,
-    fetchOgData,
-    getIconDatagByIconName,
-    checkLinkInMultipleLink,
-    fetchMultipleLinksOgData,
-    focusedAddContentIndex,
-    setFocusedAddContentIndex,
-    setMultipleTitle,
-    resetAddContentData
+    getIconDatagByIconName
   }
 })

--- a/src/stores/useModalViewStore.ts
+++ b/src/stores/useModalViewStore.ts
@@ -100,6 +100,17 @@ export const useModalViewStore = defineStore('modalView', () => {
     modal.select = true
   }
 
+  function openEditContentModal() {
+    modal.select = false
+    modal.editContent = true
+    overlay.default = true
+  }
+
+  function closeEditContentModal() {
+    modal.editContent = false
+    modal.select = true
+  }
+
   function closeAddContentSingle() {
     modal.addContentDetail = false
     closeAddContentModal()
@@ -141,6 +152,8 @@ export const useModalViewStore = defineStore('modalView', () => {
     // toastModal,
     // showErrorToast,
     // toastErrorModal,
+    openEditContentModal,
+    closeEditContentModal,
     showModalWithOverlay,
     hideModalWithOverlay,
     showModal,

--- a/src/stores/useSearchStore.ts
+++ b/src/stores/useSearchStore.ts
@@ -40,7 +40,7 @@ export const useSearchStore = defineStore('search', () => {
 
     // 콘텐츠
     searchedContent.value = toRaw(
-      getContentIdWithKeyword(keyword.value.main, contentStore.userContentList)
+      getContentIdWithKeyword(keyword.value.main, contentStore.allContentList)
     )
 
     if (searchedContent.value !== undefined) {

--- a/src/utils/interface.ts
+++ b/src/utils/interface.ts
@@ -1,5 +1,3 @@
-import type { Ref, reactive } from 'vue'
-
 interface CategoryIdMap {
   [id: number]: boolean
 }
@@ -35,4 +33,33 @@ interface Modal {
   // deleteCategory: Ref<boolean>
 }
 
-export type { CategoryIdMap, Modal, Overlay }
+interface ContentObj {
+  id: number
+  link: string
+  title: string
+  siteName: string
+  description: string
+  comment: string
+  favorite: boolean
+  categoryName: string
+  categoryIconName?: string
+  categoryId?: number
+  parentId?: number
+  createdAt?: number
+  updatedAt?: number
+  coverImg?: string
+  checked?: boolean
+  focused: boolean
+}
+
+interface OgContent {
+  link: string
+  coverImg: string
+  title: string
+  description: string
+  siteName: string
+}
+
+interface ContentList extends Array<ContentObj> {}
+
+export type { CategoryIdMap, Modal, Overlay, ContentObj, ContentList, OgContent }

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,0 +1,40 @@
+const deleteNullContentProp = (contentObj) => {
+  let contentData = contentObj
+
+  delete contentData.id
+  delete contentData.categoryId
+  delete contentData.categoryIconName
+  delete contentData.siteName
+
+  if (contentObj.categoryName === '전체 콘텐츠' || '') {
+    delete contentData.categoryName
+  }
+  if (contentObj.comment === '') {
+    delete contentData.comment
+  }
+  if (contentObj.parentId === -1) {
+    delete contentData.parentId
+  }
+  return contentData
+}
+
+const deleteNullEditContentProp = (contentObj) => {
+  let contentData = contentObj
+
+  delete contentData.categoryId
+  delete contentData.categoryIconName
+  delete contentData.siteName
+
+  if (contentObj.categoryName === '전체 콘텐츠' || '') {
+    delete contentData.categoryName
+  }
+  if (contentObj.comment === '') {
+    delete contentData.comment
+  }
+  if (contentObj.parentId === -1) {
+    delete contentData.parentId
+  }
+  return contentData
+}
+
+export { deleteNullContentProp, deleteNullEditContentProp }

--- a/src/views/ModalView.vue
+++ b/src/views/ModalView.vue
@@ -23,41 +23,46 @@
       v-if="modalViewStore.modal.editCategory"
     ></modal-category-add>
 
-    <!-- 콘텐츠 모달 -->
-    <modal-content-add-step-01
+    <!-- 콘텐츠 추가 - 단일 링크 -->
+    <modal-content-step-01
       v-if="modalViewStore.modal.addContent"
       :closeModal="closeAddContentStep01Modal"
       :modalTitle="'콘텐츠 추가'"
-    ></modal-content-add-step-01>
-    <!-- 콘텐츠 추가 - 단일 링크 -->
-    <modal-content-add-single
+    ></modal-content-step-01>
+
+    <modal-content-single
       v-if="modalViewStore.modal.addContentDetail"
       :closeModal="modalViewStore.closeAddContentSingle"
       :modalTitle="'콘텐츠 추가'"
-    ></modal-content-add-single>
+      :goBack="gobackAddContentStep01"
+    ></modal-content-single>
+
     <!-- 콘텐츠 추가 - 다중 링크 -->
-    <modal-content-add-multiple
+    <modal-content-multiple
       v-if="modalViewStore.modal.addContentMultiple"
       :closeModal="modalViewStore.closeAddContentMultiple"
       :modalTitle="'콘텐츠 추가'"
-    ></modal-content-add-multiple>
+      :goBack="gobackAddContentStep01"
+    ></modal-content-multiple>
+
+    <!-- 콘텐츠 수정 모달 -->
+    <modal-content-step-01
+      v-if="modalViewStore.modal.editContent"
+      :modalTitle="'콘텐츠 수정'"
+      :closeModal="closeEditContentStep01Modal"
+    ></modal-content-step-01>
+
+    <modal-content-single
+      v-if="modalViewStore.modal.editContentDetail"
+      :modalTitle="'콘텐츠 수정'"
+      :closeModal="closeEditContentSingle"
+      :goBack="gobackEditContentStep01"
+    ></modal-content-single>
 
     <alert-confirm
       v-if="modalViewStore.modal.deleteCategory"
       :alertData="alertDataStore.deleteCategoryAlertData"
     ></alert-confirm>
-
-    <!-- 콘텐츠 수정 모달 -->
-    <modal-content-add-step-01
-      v-if="modalViewStore.modal.editContent"
-      :modalTitle="'콘텐츠 수정'"
-      :closeModal="closeEditContentStep01Modal"
-    ></modal-content-add-step-01>
-    <modal-content-add-single
-      v-if="modalViewStore.modal.editContentDetail"
-      :modalTitle="'콘텐츠 수정'"
-      :closeModal="closeEditContentSingle"
-    ></modal-content-add-single>
 
     <!-- 콘텐츠 삭제 얼럿 -->
     <alert-confirm
@@ -98,9 +103,9 @@ import { useModalViewStore } from '@/stores/useModalViewStore.ts'
 import { useAlertDataStore } from '@/stores/useAlertDataStore.ts'
 import ModalCategorySelect from '@/components/modal/category/ModalCategorySelect.vue'
 import ModalSetCategoryLocation from '@/components/modal/category/ModalSetCategoryLocation.vue'
-import ModalContentAddStep01 from '@/components/modal/content/ModalContentAddStep01.vue'
-import ModalContentAddSingle from '@/components/modal/content/ModalContentAddSingle.vue'
-import ModalContentAddMultiple from '@/components/modal/content/ModalContentAddMultiple.vue'
+import ModalContentStep01 from '@/components/modal/content/ModalContentAddStep01.vue'
+import ModalContentSingle from '@/components/modal/content/ModalContentAddSingle.vue'
+import ModalContentMultiple from '@/components/modal/content/ModalContentAddMultiple.vue'
 import AlertDefault from '@/components/modal/alert/AlertDefault.vue'
 import AlertConfirm from '@/components/modal/alert/AlertConfirm.vue'
 import ModalEditContentTitle from '@/components/modal/content/ModalEditContentTitle.vue'
@@ -115,12 +120,22 @@ const closeAddContentStep01Modal = () => {
 }
 
 const closeEditContentStep01Modal = () => {
-  modalViewStore.hideModalWithOverlay('editContent')
+  modalViewStore.closeEditContentModal()
 }
 
 const closeEditContentSingle = () => {
   modalViewStore.hideModalWithOverlay('editContentDetail', 'default')
   modalViewStore.hideModalWithOverlay('editContent')
+}
+
+const gobackAddContentStep01 = () => {
+  modalViewStore.hideModal('addContentDetail')
+  modalViewStore.openAddContentModal()
+}
+
+const gobackEditContentStep01 = () => {
+  modalViewStore.hideModal('editContentDetail')
+  modalViewStore.openEditContentModal()
 }
 </script>
 


### PR DESCRIPTION
[내용]
- dataStore에서 관리하던 콘텐츠 상태를 contentStore로 이관
- 불필요하게 긴 함수 및 변수명 수정
- addContent, editContent로 나뉘어져 잇던 정보를 하나로 통합
- 서버로 요청 시 불필요한 콘텐츠 객체 속성들 삭제 함수 구현
- 콘텐츠 편집 시 뒤로가기 모달 버튼 비정상 동작 수정
- 기본 카테고리 아이콘 정보를 별도 파일로 분리